### PR TITLE
With tasks

### DIFF
--- a/src/main/java/solutions/dmitrikonnov/demo/HexaInitializer.java
+++ b/src/main/java/solutions/dmitrikonnov/demo/HexaInitializer.java
@@ -1,6 +1,10 @@
 package solutions.dmitrikonnov.demo;
 
+
+/**
+ * Let us initialize a subclass with a superclass' common method without using reflection.
+ * */
 @FunctionalInterface
 public interface HexaInitializer<T> {
-    T initializeWithInt(int[][]matrix, int[][]newMatrix, int i, int j,int k ,int l);
+    T initialize(int[][]matrix, int[][]newMatrix, int i, int j, int k , int l);
 }

--- a/src/main/java/solutions/dmitrikonnov/demo/HexaInitializer.java
+++ b/src/main/java/solutions/dmitrikonnov/demo/HexaInitializer.java
@@ -1,9 +1,6 @@
 package solutions.dmitrikonnov.demo;
-/**
- *
- * I could have called it HeptaSupplier, which effectively it is, but I didn't.
- * */
+
 @FunctionalInterface
-public interface HexaInitializer<Q,W,E,R,T,Y,U> {
-    U getInstance(Q q, W w, E e, R r, T t, Y y);
+public interface HexaInitializer<T> {
+    T initializeWithInt(int[][]matrix, int[][]newMatrix, int i, int j,int k ,int l);
 }

--- a/src/main/java/solutions/dmitrikonnov/demo/HexaSupplier.java
+++ b/src/main/java/solutions/dmitrikonnov/demo/HexaSupplier.java
@@ -1,0 +1,10 @@
+package solutions.dmitrikonnov.demo;
+
+/**
+ * HexaSupplier is supposed to be used with Generics on the equal terms as HexaInitializer
+ * */
+
+@FunctionalInterface
+public interface HexaSupplier<Q,W,E,R,T,Y,U> {
+    U get(Q q, W w, E e, R r, T t, Y y);
+}

--- a/src/main/java/solutions/dmitrikonnov/demo/MatrixRotatorRecursiveAbstractTask.java
+++ b/src/main/java/solutions/dmitrikonnov/demo/MatrixRotatorRecursiveAbstractTask.java
@@ -45,7 +45,7 @@ public abstract class MatrixRotatorRecursiveAbstractTask extends RecursiveAction
                 .forEach(d-> dividedTasks.
                 add(
                         (getOperator()
-                                .initializeWithInt(
+                                .initialize(
                                         matrix,
                                         newMatrix,
                                         THRESHOLD*d,
@@ -60,7 +60,7 @@ public abstract class MatrixRotatorRecursiveAbstractTask extends RecursiveAction
         int divider = (l-j)/THRESHOLD;
 
         IntStream.range(0,divider)
-                .forEach(d-> dividedTasks.add( getOperator().initializeWithInt(
+                .forEach(d-> dividedTasks.add( getOperator().initialize(
                 matrix,
                 newMatrix,
                 i,
@@ -81,7 +81,7 @@ public abstract class MatrixRotatorRecursiveAbstractTask extends RecursiveAction
 
         IntStream.range(0,dividerVertical)
                 .forEach(dv-> IntStream.range(0, dividerHorizontal)
-                        .forEach(dh-> dividedTasks.add(getOperator().initializeWithInt(
+                        .forEach(dh-> dividedTasks.add(getOperator().initialize(
                                 matrix,
                                 newMatrix,
                                 THRESHOLD*dv,

--- a/src/main/java/solutions/dmitrikonnov/demo/MatrixRotatorRecursiveAbstractTask.java
+++ b/src/main/java/solutions/dmitrikonnov/demo/MatrixRotatorRecursiveAbstractTask.java
@@ -13,7 +13,8 @@ public abstract class MatrixRotatorRecursiveAbstractTask extends RecursiveAction
     int[][] newMatrix;
     int i,j,k,l;
 
-    abstract HexaInitializer<int[][], int[][], int, int, int, int, ? extends MatrixRotatorRecursiveAbstractTask> getSubtaskInitializer();
+
+    abstract HexaInitializer<? extends MatrixRotatorRecursiveAbstractTask> getOperator();
     MatrixRotatorRecursiveAbstractTask(int[][] matrix) {
         if(matrix.length!=matrix[0].length) throw new RuntimeException("Rotating of matrix with unequal length and with is not implemented!");
         this.matrix = matrix;
@@ -43,8 +44,8 @@ public abstract class MatrixRotatorRecursiveAbstractTask extends RecursiveAction
         IntStream.range(0,divider)
                 .forEach(d-> dividedTasks.
                 add(
-                        (getSubtaskInitializer()
-                                .getInstance(
+                        (getOperator()
+                                .initializeWithInt(
                                         matrix,
                                         newMatrix,
                                         THRESHOLD*d,
@@ -59,7 +60,7 @@ public abstract class MatrixRotatorRecursiveAbstractTask extends RecursiveAction
         int divider = (l-j)/THRESHOLD;
 
         IntStream.range(0,divider)
-                .forEach(d-> dividedTasks.add( getSubtaskInitializer().getInstance(
+                .forEach(d-> dividedTasks.add( getOperator().initializeWithInt(
                 matrix,
                 newMatrix,
                 i,
@@ -80,7 +81,7 @@ public abstract class MatrixRotatorRecursiveAbstractTask extends RecursiveAction
 
         IntStream.range(0,dividerVertical)
                 .forEach(dv-> IntStream.range(0, dividerHorizontal)
-                        .forEach(dh-> dividedTasks.add(getSubtaskInitializer().getInstance(
+                        .forEach(dh-> dividedTasks.add(getOperator().initializeWithInt(
                                 matrix,
                                 newMatrix,
                                 THRESHOLD*dv,

--- a/src/main/java/solutions/dmitrikonnov/demo/MatrixRotatorRecursiveInVirtualThreadsTask.java
+++ b/src/main/java/solutions/dmitrikonnov/demo/MatrixRotatorRecursiveInVirtualThreadsTask.java
@@ -13,11 +13,16 @@ public class MatrixRotatorRecursiveInVirtualThreadsTask extends MatrixRotatorRec
         super(matrix, newMatrix, i, j, k, l);
     }
 
-    @Override
-    HexaInitializer<int[][], int[][], int, int, int, int,MatrixRotatorRecursiveInVirtualThreadsTask> getSubtaskInitializer() {
-        return MatrixRotatorRecursiveInVirtualThreadsTask::new;
-
+   @Override
+   HexaInitializer<MatrixRotatorRecursiveInVirtualThreadsTask> getOperator(){
+        HexaInitializer<MatrixRotatorRecursiveInVirtualThreadsTask> operator = (matrix, newMatrix, i, j, k, l) -> {
+            return new MatrixRotatorRecursiveInVirtualThreadsTask(matrix,newMatrix,i,j,k,l);
+        };
+        return operator;
     }
+
+
+
 
     @Override
     public void compute() {

--- a/src/main/java/solutions/dmitrikonnov/demo/MatrixRotatorRecursiveTask.java
+++ b/src/main/java/solutions/dmitrikonnov/demo/MatrixRotatorRecursiveTask.java
@@ -1,11 +1,6 @@
 package solutions.dmitrikonnov.demo;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.ForkJoinTask;
-import java.util.concurrent.RecursiveAction;
-import java.util.stream.IntStream;
 
 public class MatrixRotatorRecursiveTask extends MatrixRotatorRecursiveAbstractTask implements MatrixRotatorTask {
 
@@ -18,9 +13,11 @@ public class MatrixRotatorRecursiveTask extends MatrixRotatorRecursiveAbstractTa
     }
 
     @Override
-    HexaInitializer<int[][], int[][], int, int, int, int,MatrixRotatorRecursiveTask> getSubtaskInitializer() {
-        return MatrixRotatorRecursiveTask::new;
-
+    HexaInitializer<MatrixRotatorRecursiveTask> getOperator(){
+        HexaInitializer<MatrixRotatorRecursiveTask> operator = (matrix, newMatrix, i, j, k, l) -> {
+            return new MatrixRotatorRecursiveTask(matrix,newMatrix,i,j,k,l);
+        };
+        return operator;
     }
 
     /**


### PR DESCRIPTION
Since HexaSupplier Functional Interface is supposed to be used with Generics, I added a less generic HexaInitializer FI, which allows me to avoid boxing/unboxing of primitives.